### PR TITLE
Fixed background of the modal windows and removed the X button.

### DIFF
--- a/templates/connect4.html
+++ b/templates/connect4.html
@@ -57,14 +57,11 @@
   </div>
 
   <div class="modal fade" id="endModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle"
-    aria-hidden="true">
+    aria-hidden="true" data-backdrop="static">
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="exampleModalCenterTitle">Game over!</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
         </div>
         <div class="modal-body">
           <b id='gameResult'></b>

--- a/templates/snakegame.html
+++ b/templates/snakegame.html
@@ -63,9 +63,6 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="exampleModalCenterTitle">Ola!</h5>
-                    <!-- <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span> -->
-                    </button>
                 </div>
                 <div class="modal-body">
                     Are you ready to play?
@@ -79,14 +76,11 @@
         </div>
     </div>
     <div class="modal fade" id="endModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle"
-        aria-hidden="true">
+        aria-hidden="true" data-backdrop="static">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="exampleModalCenterTitle">Game over!</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
                 </div>
                 <div class="modal-body">
                     <b id='gameResult'></b>


### PR DESCRIPTION
In reference to issue #18

After the changes, in both games it is not anymore possible to skip the closure modal window. The player has to choose one of the two options or else the website will not redirect.