### PR TITLE
Update to Flask 2.x, fix Werkzeug dependency issue, operator fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 flaskenv/
+venv/
 config.pyc
 server.pyc
 tools.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-Flask==1.1.1
+Flask==2.1.1
 flask_mysqldb==0.2.0
-flask_socketio==4.2.1
+flask_socketio==4.3.2
+Werkzeug==2.0.1
+

--- a/server.py
+++ b/server.py
@@ -58,13 +58,13 @@ def Register():
         lastName = request.form['lastName']
 
         #Valid input check
-        if(len(email) is 0):
+        if(len(email) == 0):
             error = 'Email cannot be empty'
             return render_template('register.html', error = error)
         if (len(password) < 8):
             error = 'Password must be 8 characters long'
             return render_template('register.html', error = error)
-        if (len(firstName) is 0):
+        if (len(firstName) == 0):
             error = 'First Name cannot be empty'
             return render_template('register.html', error = error)
         
@@ -73,7 +73,7 @@ def Register():
         _sql = "select * from Login_Credentials where PlayerID = '{0}'"
         cur.execute(_sql.format(email))
         data=cur.fetchall()
-        if(len(data) is 0):
+        if(len(data) == 0):
             error = None
             cur.execute("INSERT INTO Player_Profile(PlayerID,firstName,lastName) VALUES(%s,%s,%s)",(email,firstName,lastName))
             cur.execute("INSERT INTO Login_Credentials VALUES(%s,MD5(%s))",(email,password))
@@ -97,7 +97,7 @@ def Login():
         _sql = "select password from Login_Credentials where PlayerID = '{0}'"
         cur.execute(_sql.format(email))
         stored=cur.fetchall()
-        if(len(stored) is 0):
+        if(len(stored) == 0):
             error = 'Email not found!'
         else:
             if(enc_string==stored):
@@ -407,7 +407,7 @@ def buyPerk(arr):
         cur.execute(_sql.format(email,arr[1]))
         stored=cur.fetchall()
         # print(stored)
-        if(len(stored) is 0):
+        if(len(stored) == 0):
             quantity = 1
             _sql = "insert into Owned_Perk values('{0}',{1},{2})"
             cur.execute(_sql.format(email,arr[1],quantity))


### PR DESCRIPTION
Not tied to an issue, but this fix solves three main issues I ran when setting up, tied to some outdated packages:

1. jinja2 error at runtime, fixed by moving from Flask `1.1.1` to `2.1.1`

`ImportError: cannot import name 'escape' from 'jinja2' (/home/venus/stuff/Multiplayer-Game-Server/venv/lib/python3.10/site-packages/jinja2/__init__.py)`

2. Werkzeug error at runtime, fixed by using Werkzeug `2.x` and specifying in `requirements.txt`

`ImportError: cannot import name 'run_with_reloader' from 'werkzeug.serving' (/home/venus/stuff/Multiplayer-Game-Server/venv/lib/python3.10/site-packages/werkzeug/serving.py)`

3. SyntaxWarning: "is" with a literal. Did you mean "=="? Fixed by swapping to equality operator on all five accounts

`/home/venus/stuff/Multiplayer-Game-Server/server.py:61: SyntaxWarning: "is" with a literal. Did you mean "=="?`

Also added `venv/` to `.gitignore` as my aliases are set up for my venv to be named such.